### PR TITLE
Refactor border percentage handling to use getFloat and format

### DIFF
--- a/src/loader/config/config.c
+++ b/src/loader/config/config.c
@@ -314,8 +314,8 @@ void applyIniConfig(EmulatorConfig *config, const IniConfig *ini)
     config->boostRenderRes = getInt(ini, "Display", "BOOST_RENDER_RES", config->boostRenderRes);
     config->fullscreen = getInt(ini, "Display", "FULLSCREEN", config->fullscreen);
     config->borderEnabled = getInt(ini, "Display", "BORDER_ENABLED", config->borderEnabled);
-    config->whiteBorderPercentage = getInt(ini, "Display", "WHITE_BORDER_PERCENTAGE", config->whiteBorderPercentage * 100) / 100.0f;
-    config->blackBorderPercentage = getInt(ini, "Display", "BLACK_BORDER_PERCENTAGE", config->blackBorderPercentage * 100) / 100.0f;
+	config->whiteBorderPercentage = getFloat(ini, "Display", "WHITE_BORDER_PERCENTAGE", config->whiteBorderPercentage * 100.0f) / 100.0f;
+	config->blackBorderPercentage = getFloat(ini, "Display", "BLACK_BORDER_PERCENTAGE", config->blackBorderPercentage * 100.0f) / 100.0f;
     config->keepAspectRatio = getInt(ini, "Display", "KEEP_ASPECT_RATIO", config->keepAspectRatio);
     config->hideCursor = getInt(ini, "Display", "HIDE_CURSOR", config->hideCursor);
 

--- a/src/loader/config/configIni.c
+++ b/src/loader/config/configIni.c
@@ -30,10 +30,10 @@ int createDefaultIni(const char *filePath)
     fprintf(file, "# Set to true if you\'d like to add a border for optical light gun tracking\n");
     fprintf(file, "BORDER_ENABLED = %s\n\n", defaults.borderEnabled ? "true" : "false");
     fprintf(file, "# Set the thickness of the white border as a percentage of the width of the screen\n");
-    fprintf(file, "WHITE_BORDER_PERCENTAGE = %.0f\n\n", defaults.whiteBorderPercentage * 100);
+    fprintf(file, "WHITE_BORDER_PERCENTAGE = %.1f\n\n", defaults.whiteBorderPercentage * 100.0f);
     fprintf(file, "# Set the thickness of the black border which sits around the\n");
     fprintf(file, "# white border as a percentage of the width of the screen\n");
-    fprintf(file, "BLACK_BORDER_PERCENTAGE = %.0f\n\n", defaults.blackBorderPercentage * 100);
+    fprintf(file, "BLACK_BORDER_PERCENTAGE = %.1f\n\n", defaults.blackBorderPercentage * 100.0f);
     fprintf(file, "# Set to keep the aspect ratio in games like Sega Race TV Primeval Hunt and LGJ-SP\n");
     fprintf(file, "KEEP_ASPECT_RATIO = %s\n\n", defaults.keepAspectRatio ? "true" : "false");
     fprintf(file, "# Set to true to enable the mouse pointer/Cursor\nHIDE_CURSOR = %s\n\n", defaults.hideCursor ? "true" : "false");


### PR DESCRIPTION
Allows using 0.x values instead of whole numbers for more flexibility in border size.