### PR TITLE
Fix ABC aspect handling in keep-aspect mode

### DIFF
--- a/src/loader/graphics/blitStretching.c
+++ b/src/loader/graphics/blitStretching.c
@@ -58,6 +58,8 @@ void initBlitting()
 
 void blitSetWidthandHeightSize()
 {
+    EmulatorConfig *config = getConfig();
+
     if (gGrp == GROUP_ID4_EXP || gGrp == GROUP_ID4_JAP || gGrp == GROUP_ID5)
     {
         if (isTestMode())
@@ -72,6 +74,11 @@ void blitSetWidthandHeightSize()
         }
     }
     else if (gId == GHOST_SQUAD_EVOLUTION_SBNJ || gGrp == GROUP_VT3_TEST)
+    {
+        blitWidth = 640;
+        blitHeight = 480;
+    }
+    else if (gGrp == GROUP_ABC && config->keepAspectRatio)
     {
         blitWidth = 640;
         blitHeight = 480;
@@ -189,17 +196,45 @@ void blitStretch()
 
         glad_glReadBuffer(GL_BACK);
         CHECK_GL("readbuffer GL_BACK");
+		
+		#ifdef _WIN32
+        GLint vp[4];
+        glad_glGetIntegerv(GL_VIEWPORT, vp);
+		#endif
 
-        glad_glBlitFramebuffer(0, 0, blitWidth, blitHeight, 0, 0, blitWidth, blitHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-        CHECK_GL("first blit to fboId");
+		#ifdef _WIN32
+        if (gGrp == GROUP_ABC && vp[2] > blitWidth && vp[3] > blitHeight)
+        {
+            glad_glBlitFramebuffer(
+                vp[0], vp[1],
+                vp[0] + vp[2], vp[1] + vp[3],
+                0, 0,
+                blitWidth, blitHeight,
+                GL_COLOR_BUFFER_BIT,
+                GL_NEAREST
+            );
+        }
+        else
+		#endif
+        {
+            glad_glBlitFramebuffer(
+                0, 0,
+                blitWidth, blitHeight,
+                0, 0,
+                blitWidth, blitHeight,
+                GL_COLOR_BUFFER_BIT,
+                GL_NEAREST
+            );
+        }
+		CHECK_GL("first blit to fboId");
 
         float gameAspect = (float)blitWidth / (float)blitHeight;
-        float windowAspect = (float)drawableW / (float)drawableH;
+		float windowAspect = (float)drawableW / (float)drawableH;
 
         dest.W = drawableW;
         dest.H = drawableH;
 
-        if (windowAspect > gameAspect)
+		if (windowAspect > gameAspect)
         {
             dest.W = (GLsizei)(drawableH * gameAspect);
             dest.X = (drawableW - dest.W) / 2;
@@ -209,7 +244,7 @@ void blitStretch()
             dest.H = (GLsizei)(drawableW / gameAspect);
             dest.Y = (drawableH - dest.H) / 2;
         }
-
+	   
         glad_glBindFramebuffer(GL_FRAMEBUFFER, 0);
         CHECK_GL("bind default framebuffer");
 

--- a/src/loader/graphics/blitStretching.c
+++ b/src/loader/graphics/blitStretching.c
@@ -78,11 +78,13 @@ void blitSetWidthandHeightSize()
         blitWidth = 640;
         blitHeight = 480;
     }
+#ifdef _WIN32
     else if (gGrp == GROUP_ABC && config->keepAspectRatio)
     {
         blitWidth = 640;
         blitHeight = 480;
     }
+#endif
     else if (gId == QUIZ_AXA_SBMS || gId == QUIZ_AXA_SBUR_LIVE || gId == MJ4_SBPN_REVG || gId == MJ4_EVO_SBTA)
     {
         blitWidth = 1024;


### PR DESCRIPTION
Fixes ABC stretching to full 16:9 when manually set to 1920x1080 with KEEP_ASPECT_RATIO enabled.

Before this, ABC would boot looking stretched/wrong at first. Once it reached the high score screen / attract mode, it would correct itself and fit properly, which made it look like the render size changed partway through startup.

The issue was that ABC was using the manual window size as the blit size, so the aspect math treated it like it was already 16:9. This keeps ABC treated as 640x480 in the Windows keep-aspect path, so it stays 4:3 / 1440x1080 inside a 1920x1080 window.

KEEP_ASPECT_RATIO=false still fills the full window like before, and AUTO resolution behavior should be unchanged.

The Windows-only guard was added so this does not change Linux behavior without testing it there first.

**AI Disclosure**: AI assistance was used as a learning/reference aid and for error checking during this PR. The implementation, testing, debugging, and final review were performed manually.